### PR TITLE
Update config.txt line buffer size and value size

### DIFF
--- a/AtomGPS_wigler.ino
+++ b/AtomGPS_wigler.ino
@@ -299,7 +299,7 @@ void updateTimePerChannel(int channel, int networksFound) {  // BETA feature, ad
 }
 // SD Config
 void parseConfigFile(File file) {
-  char line[64];
+  char line[80];
   int lineIndex = 0;
   while (file.available()) {
     char c = file.read();
@@ -321,7 +321,7 @@ void parseConfigFile(File file) {
 
 void processConfigLine(const char* line) {
   char key[32];
-  char value[32];
+  char value[48];
   sscanf(line, "%[^=]=%s", key, value);
 
   if (strcmp(key, "speedBased") == 0) {


### PR DESCRIPTION
up config file line length to 80 and Value length to 48 to accommodate full channel list

When supplying all channels 1-14, the value portion is 41 characters in length. So we need a little more headroom to hold it

channels=1,2,3,4,5,6,7,8,9,10,11,12,13,14  ( 41 chars)